### PR TITLE
css: add busID to bookmark

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -101,6 +101,11 @@ body {
 .bookmarkedStop {
   color: var(--colorBrandForegroundLink);
   cursor: pointer;
+  margin: auto 8px auto 4px;
+}
+
+.bookmarkedStop span {
+  white-space: nowrap;
 }
 
 .navBar > a {
@@ -160,11 +165,10 @@ main {
 }
 
 .card-row {
-  display: grid;
-  grid-template-columns: auto auto;
-  align-items: center;
-  gap: 1rem;
-  padding: 0 0.2rem;
+  display: flex;
+  overflow-x: scroll;
+  overflow-y: hidden;
+  max-height: 36px;
 }
 
 .bookmarks a,
@@ -183,6 +187,10 @@ pre {
 }
 
 @media screen and (min-width: 800px) {
+  .homePage {
+    width: 560px;
+  }
+
   .container {
     flex-direction: row;
   }

--- a/src/features/bookmarks/BookmarkCard.tsx
+++ b/src/features/bookmarks/BookmarkCard.tsx
@@ -1,4 +1,4 @@
-import { Button, Text } from "@fluentui/react-components";
+import { Badge, Button, Text } from "@fluentui/react-components";
 import { Card } from "@fluentui/react-components/unstable";
 import { Delete24Regular } from "@fluentui/react-icons";
 import { t } from "i18next";
@@ -6,12 +6,14 @@ import { useCallback } from "react";
 import { Link } from "react-router-dom";
 
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
+import { fluentStyles } from "../../styles/fluent";
 import { removeStopBookmark } from "./stopBookmarkSlice";
 
 export function BookmarkCard(props: { id: number }) {
   const id = props.id;
   const dispatch = useAppDispatch();
   const stopBookmarks = useAppSelector((state) => state.stopBookmarks);
+  const fluentStyle = fluentStyles();
 
   const checkBookmarkStatus = useCallback(() => {
     dispatch(removeStopBookmark(props.id));
@@ -20,12 +22,22 @@ export function BookmarkCard(props: { id: number }) {
   return (
     <Card>
       <div className="card-row">
-        <Link to={`stops/${stopBookmarks.entities[id].stopId}`}>
-          <Text className="bookmarkedStop" weight="semibold">
-            {stopBookmarks.entities[id].name}
-          </Text>
+        {stopBookmarks.entities[id].lines !== undefined &&
+          stopBookmarks.entities[id].lines.map((line: string) => {
+            return (
+              <Badge className={fluentStyle.badge} key={line}>
+                {line}
+              </Badge>
+            );
+          })}
+        <Link
+          className="bookmarkedStop"
+          to={`stops/${stopBookmarks.entities[id].stopId}`}
+        >
+          <Text weight="semibold">{stopBookmarks.entities[id].name}</Text>
         </Link>
         <Button
+          className={fluentStyle.removeButton}
           title={t("buttons.delete") ?? "delete"}
           icon={<Delete24Regular />}
           onClick={checkBookmarkStatus}

--- a/src/styles/fluent.ts
+++ b/src/styles/fluent.ts
@@ -4,9 +4,13 @@ export const fluentStyles = makeStyles({
   fluentProvider: {
     height: "100%",
   },
+  removeButton: {
+    maxHeight: "32px",
+    maxWidth: "32px",
+  },
   badge: {
     ...shorthands.margin("0.5rem", "0.25rem"),
-    minWidth: "2.5rem",
+    minWidth: "min-content",
   },
   accordionHeader: {
     ...shorthands.margin("0.25rem", "0"),


### PR DESCRIPTION
Add busID to bookmarkedItems as a `temporary fix` for duplicated bookmarkedItems

Before
<img width="290" alt="duplicatedBoomarkedItemsWObusID" src="https://user-images.githubusercontent.com/25817487/212812411-284afbdf-39fb-4121-b145-58753926889c.png">

After
<img width="517" alt="Screenshot 2023-01-16 at 11 46 45 PM" src="https://user-images.githubusercontent.com/25817487/212812501-8d7fd183-8143-45c3-a5af-faf881dc85b4.png">

Long term fix: 
Aggregate stopIDs in the same stops and show all related bus in one bookmarkedItem
