### PR TITLE
fix: keep eta on refresh

### DIFF
--- a/src/components/FetchStop.tsx
+++ b/src/components/FetchStop.tsx
@@ -22,8 +22,6 @@ function StopPredictionInfo(props: { stopId: number }): JSX.Element {
 
   const handleRefreshClick = useCallback(() => {
     setLastUpdatedAt(Date.now());
-    setData(undefined);
-    setEtaDb([]);
   }, [lastUpdatedAt]);
 
   function RefreshButton() {


### PR DESCRIPTION
Avoid jumping to loading screen when refreshing page with ETAs