### PR TITLE
Improve french locale, add new locale for some hard-coded verbiage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TTC ETA
 
-A extremely fast and simple website, parsing TTC's ETA data.
+An extremely fast and simple website, parsing TTC's ETA data.
 
 ## Goals
 
@@ -31,6 +31,6 @@ docker-compose up
 
 If you are not familiar with coding, spread the word! I'd love it to be helpful to more people. If you got some idea, make an issue about it.
 
-If you know some coding, welcome! Please consider using the latest packages and writing standard to keep debt to a minimum. Small cosmetic imporvements and translations are also very welcome.
+If you know some coding, welcome! Please consider using the latest packages and writing standard to keep debt to a minimum. Small cosmetic improvements and translations are also very welcome.
 
-If you want to make a new feature or do a total design change, consider making a feature request before start working on it to avoid unhappy faces down the line.
+If you want to make a new feature or do a total design change, consider making a feature request before starting work on it to avoid unhappy faces down the line.

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -118,14 +118,14 @@ export function Settings() {
           {t("nav.label.about")}
         </Button>
       </Link>
-      <Title2>ETA lists</Title2>
+      <Title2>{t("settings.etaLists")}</Title2>
       <RadioGroup
         defaultValue={unifiedEta.toString()}
         aria-labelledby={"Unifed ETA mode"}
         onChange={handleUnifiedEtaChange}
       >
-        <Radio value="false" label={"separate for each line"} />
-        <Radio value="true" label={"single list"} />
+        <Radio value="false" label={t("settings.separateLines")} />
+        <Radio value="true" label={t("settings.singleList")} />
       </RadioGroup>
       <form className={style["search-block"]}>
         <Input

--- a/src/i18n/en/locales.json
+++ b/src/i18n/en/locales.json
@@ -29,7 +29,7 @@
     "title": "Enter a line number:",
     "number": "Line {{lineNum}}",
     "lineAndStopInfo": "Line {{lineNum}} Stop {{stopNum}} =",
-    "noLineInDb": "Error: This line is not in the route database.<br />Subway lines are unsupported for now."
+    "noLineInDb": "Error: This line is not in the route database. Subway lines are unsupported for now."
   },
   "settings": {
     "etaLists": "ETA lists",

--- a/src/i18n/en/locales.json
+++ b/src/i18n/en/locales.json
@@ -73,7 +73,7 @@
   },
   "lang": {
     "en": "English",
-    "fr": "Français",
+    "fr": "français",
     "zh": "中文"
   }
 }

--- a/src/i18n/en/locales.json
+++ b/src/i18n/en/locales.json
@@ -16,7 +16,11 @@
     },
     "headline": "You'll see saved stops here.",
     "bookmarkReminder": "Try clicking the bookmark icons on a stop you frequently visit.",
-    "homeNoEta": "All your bookmarked stops have no ETA."
+    "homeNoEta": "All your bookmarked stops have no ETA.",
+    "nextVehicle": "Next vehicle",
+    "or": "or",
+    "orSee": "Or, see",
+    "allRoutes": "All routes"
   },
   "lines": {
     "ariaLabel": "enter a line number",
@@ -26,6 +30,11 @@
     "number": "Line {{lineNum}}",
     "lineAndStopInfo": "Line {{lineNum}} Stop {{stopNum}} =",
     "noLineInDb": "Error: This line is not in the route database.<br />Subway lines are unsupported for now."
+  },
+  "settings": {
+    "etaLists": "ETA lists",
+    "separateLines": "separate for each line",
+    "singleList": "single list"
   },
   "stops": {
     "ariaLabel": "Bus / streetcar stop No.",
@@ -64,7 +73,7 @@
   },
   "lang": {
     "en": "English",
-    "fr": "Français (traduction automatique)",
+    "fr": "Français",
     "zh": "中文"
   }
 }

--- a/src/i18n/fr/locales.json
+++ b/src/i18n/fr/locales.json
@@ -15,7 +15,7 @@
       "tooltip": "Retourner à l'accueil"
     },
     "headline": "Vous verrez vos arrêts enregistrés ici.",
-    "bookmarkReminder": "Trouver l'icône de signet pour ajouter vos arrêts",
+    "bookmarkReminder": "Trouver l'icône de signet pour ajouter vos arrêts.",
     "homeNoEta": "Aucun des arrêts enregistrés n'a d'arrivée prévue.",
     "nextVehicle": "Prochain véhicule",
     "or": "ou",

--- a/src/i18n/fr/locales.json
+++ b/src/i18n/fr/locales.json
@@ -37,8 +37,8 @@
     "singleList": "afficher une liste simple"
   },
   "stops": {
-    "ariaLabel": "entrer le numéro d'identification d'arrêt",
-    "stopId": "numéro d'identification d'arrêt : {{stopNum}} ="
+    "ariaLabel": "entrer le numéro d'arrêt",
+    "stopId": "numéro d'arrêt : {{stopNum}} ="
   },
   "buttons": {
     "search": "Rechercher",

--- a/src/i18n/fr/locales.json
+++ b/src/i18n/fr/locales.json
@@ -6,48 +6,57 @@
       "about": "Aide",
       "lang": "Langue",
       "settings": "Paramètres",
-      "bookmarks": "Signet"
+      "bookmarks": "Signets"
     }
   },
   "home": {
     "title": {
       "name": "TO bus",
-      "tooltip": "Rentrer à la maison"
+      "tooltip": "Retourner à l'accueil"
     },
-    "headline": "Vous verrez des listes enregistrées ici, dans le FUTUR. <br />",
-    "bookmarkReminder": "Essayez de cliquer sur les icônes de signet sur un arrêt que vous visitez fréquemment.",
-    "homeNoEta": "Tous vos arrêts marqués n'ont pas d'ETA."
+    "headline": "Vous verrez vos arrêts enregistrés ici.",
+    "bookmarkReminder": "Trouver l'icône de signet pour ajouter vos arrêts",
+    "homeNoEta": "Aucun des arrêts enregistrés n'a d'arrivée prévue.",
+    "nextVehicle": "Prochain véhicule",
+    "or": "ou",
+    "orSee": "Ou, voir",
+    "allRoutes": "Toutes les lignes"
   },
   "lines": {
-    "ariaLabel": "entrer un n° de ligne",
-    "placeholder": "nombre de lignes",
-    "browserTitle": "Lignes {{lineNum}} | TO bus",
+    "ariaLabel": "entrer un numéro de ligne",
+    "placeholder": "entrer un numéro de ligne",
+    "browserTitle": "Ligne {{lineNum}} | TO bus",
     "title": "Entrer un numéro de ligne:",
-    "number": "Lignes {{lineNum}}",
-    "lineAndStopInfo": "Lignes {{lineNum}} Arrêt de {{stopNum}} =",
-    "noLineInDb": "Erreur : Cette ligne n'est pas dans la base de données d'itinéraires.<br />Les lignes de métro ne sont pas prises en charge pour le moment."
+    "number": "Ligne {{lineNum}}",
+    "lineAndStopInfo": "Ligne {{lineNum}} Arrêt {{stopNum}} =",
+    "noLineInDb": "Erreur : Cette ligne n'est pas dans la base de données d'itinéraires. Les lignes de métro ne sont pas prises en charge pour le moment."
+  },
+  "settings": {
+    "etaLists": "Liste des arrivées prévues",
+    "separateLines": "afficher chaque ligne séparément",
+    "singleList": "afficher une liste simple"
   },
   "stops": {
-    "ariaLabel": "entrer n° de arrêt",
-    "stopId": "Arrêt de ID {{stopNum}} ="
+    "ariaLabel": "entrer le numéro d'identification d'arrêt",
+    "stopId": "numéro d'identification d'arrêt : {{stopNum}} ="
   },
   "buttons": {
-    "search": "Chercher",
-    "refresh": "Rafraîchir",
-    "clear": "Tout effacer",
-    "mapPin": "Voir l'emplacement sur google maps",
-    "busIcon": "voir les heures d'arrivée",
-    "languageChange": "sélection de la langue",
-    "delete": "effacer",
-    "bookmarkAdd": "Ajouter au signet",
-    "bookmarkDelete": "Supprimer le signet",
-    "bookmarkEdit": "Edit bookmarks"
+    "search": "Rechercher",
+    "refresh": "Actualiser",
+    "clear": "Tout supprimer",
+    "mapPin": "Voir l'emplacement sur Google Maps",
+    "busIcon": "Voir les heures d'arrivées prévues",
+    "languageChange": "Sélectionner la langue",
+    "delete": "Effacer",
+    "bookmarkAdd": "Ajouter signet",
+    "bookmarkDelete": "Supprimer signet",
+    "bookmarkEdit": "Modifier mes signets"
   },
   "reminder": {
     "failToLocate": "Impossible de localiser cet itinéraire.",
     "wrongPlace": "Ne devrait pas être ici :/",
     "loading": "Chargement...",
-    "noEta": "Pas d'arrivées à venir."
+    "noEta": "Pas d'arrivées prévues."
   },
   "error": {
     "notFound": "Erreur: cette page n'existe pas."

--- a/src/i18n/fr/locales.json
+++ b/src/i18n/fr/locales.json
@@ -48,8 +48,8 @@
     "busIcon": "Voir les heures d'arrivées prévues",
     "languageChange": "Sélectionner la langue",
     "delete": "Effacer",
-    "bookmarkAdd": "Ajouter signet",
-    "bookmarkDelete": "Supprimer signet",
+    "bookmarkAdd": "Ajouter un signet",
+    "bookmarkDelete": "Supprimer un signet",
     "bookmarkEdit": "Modifier mes signets"
   },
   "reminder": {

--- a/src/i18n/zh/locales.json
+++ b/src/i18n/zh/locales.json
@@ -14,7 +14,7 @@
       "name": "TTC 到站時間",
       "tooltip": "回主頁"
     },
-    "headline": "加落書籤嘅站會出現響呢度。 <br />",
+    "headline": "加落書籤嘅站會出現響呢度。",
     "bookmarkReminder": "(試下響你成日等車嘅站撳個書籤 icon)",
     "homeNoEta": "你所有書籤裏面嘅站都冇下班車嘅資料。",
     "nextVehicle": "Next vehicle",
@@ -29,7 +29,7 @@
     "title": "輸入路線:",
     "number": "{{lineNum}} 號線",
     "lineAndStopInfo": "{{lineNum}} 線 #{{stopNum}} 站 =",
-    "noLineInDb": "資料庫裏面冇呢條線嘅資料。<br />(暫時睇唔到地鐵路線)"
+    "noLineInDb": "資料庫裏面冇呢條線嘅資料。(暫時睇唔到地鐵路線)"
   },
   "stops": {
     "ariaLabel": "輸入車站號碼",

--- a/src/i18n/zh/locales.json
+++ b/src/i18n/zh/locales.json
@@ -16,7 +16,11 @@
     },
     "headline": "加落書籤嘅站會出現響呢度。 <br />",
     "bookmarkReminder": "(試下響你成日等車嘅站撳個書籤 icon)",
-    "homeNoEta": "你所有書籤裏面嘅站都冇下班車嘅資料。"
+    "homeNoEta": "你所有書籤裏面嘅站都冇下班車嘅資料。",
+    "nextVehicle": "Next vehicle",
+    "or": "or",
+    "orSee": "Or, see",
+    "allRoutes": "All routes"
   },
   "lines": {
     "ariaLabel": "輸入路線",
@@ -30,6 +34,11 @@
   "stops": {
     "ariaLabel": "輸入車站號碼",
     "stopId": "車站編號 {{stopNum}}  ="
+  },
+  "settings": {
+    "etaLists": "ETA lists",
+    "separateLines": "separate for each line",
+    "singleList": "single list"
   },
   "buttons": {
     "search": "搜尋",

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -20,9 +20,9 @@ export default function Home() {
           <p>{t("home.headline")}</p>
           <p>{t("home.bookmarkReminder")}</p>
           <p>
-            Or, see
+            {t("home.orSee")}
             <Link style={{ marginLeft: "1rem" }} to="/lines">
-              <Button>All routes</Button>
+              <Button>{t("home.allRoutes")}</Button>
             </Link>
           </p>
         </section>

--- a/src/routes/Search.tsx
+++ b/src/routes/Search.tsx
@@ -36,7 +36,7 @@ export default function NewVehicle() {
     <div className="search-form">
       <form className={style["next-vehicle-container"]}>
         <div className={style.title}>
-          <Title1>Next Vehicle</Title1>
+          <Title1>{t("home.nextVehicle")}</Title1>
           <Button
             type="submit"
             appearance="outline"
@@ -58,7 +58,7 @@ export default function NewVehicle() {
         />
       </form>
       <div className={style.separation}>
-        <hr /> <span>or</span> <hr />
+        <hr /> <span>{t("home.or")}</span> <hr />
       </div>
       <form className={style["search-block"]}>
         <Input


### PR DESCRIPTION
Hey, awesome site - thanks for making this!

I speak French fluently, so I thought I'd help improve the French translations. I also noticed a few spots that had English hard-coded, so I added some localization there as well.

* Add new localization in a few places that were hard-coded to English
* Update French locale, and add the new localizations I added
* Add the new localizations I added to the code to the English and Chinese locale files. The text was copied from what was hard-coded, so there should be no verbiage changes for either of these locales. Hopefully someone can help translate the new Chinese ones at some point.
* Remove a few `<br />` elements from all three locales. As you can see in the "Before" of the first screenshot below, this html was not getting rendered. 😬 
* Fix a few readme typos

## Home page updates:
![TO_bus_and_TO_bus](https://github.com/user-attachments/assets/c452f215-96c6-4287-a6c5-65015d513b8e)

## Settings page updates:
![before_and_after](https://github.com/user-attachments/assets/5f4642ae-f755-442a-af73-486b88ad9ca6)
