### PR TITLE
Parse full line number with optional letter from skeet

### DIFF
--- a/src/components/alerts/AlertUtils.tsx
+++ b/src/components/alerts/AlertUtils.tsx
@@ -18,7 +18,7 @@ export const ParsedTtcAlertText = ({
   const lineFilter = badge.line
     ? lineNum < 6
       ? `${lineNum}`
-      : `${lineNum}`
+      : badge.line
     : badge.highlightAll
       ? parseLine(feedText)
       : "";

--- a/src/components/alerts/bsky-alerts/SkeetList.tsx
+++ b/src/components/alerts/bsky-alerts/SkeetList.tsx
@@ -1,6 +1,15 @@
 import { type Skeet, SkeetElement } from "./Skeet.js";
 import style from "./SkeetList.module.css";
 
+const parseFullLineNumber = (skeets: Skeet[]) => {
+  if (skeets?.length === 0) {
+    return;
+  }
+  // Match the line number as well as any possible suffix (e.g. "A" or "B")
+  const lineTextMatch = skeets[0].post.record.text.match(/^\d{1,3}\S/);
+  return lineTextMatch?.[0];
+};
+
 export const SkeetList = ({
   skeetList,
   line,
@@ -10,7 +19,11 @@ export const SkeetList = ({
   line?: string;
   type?: string;
 }) => {
-  const badgeArg = line === "all" ? { highlightAll: true } : { line };
+  const lineNumber = parseFullLineNumber(skeetList);
+  const badgeArg =
+    line === "all"
+      ? { highlightAll: true }
+      : { line: typeof lineNumber === "string" ? lineNumber : line };
   const dataArray = skeetList.map((skeet) => (
     <SkeetElement key={skeet.post.cid} skeet={skeet} badge={badgeArg} />
   ));


### PR DESCRIPTION
Small bug fix for a parsing issue where line suffixes were being parsed out of the line and appearing after the badge (see https://github.com/thomassth/ttc-bus-eta/issues/191).

Before:

<img width="356" height="180" alt="Screenshot 2025-08-01 at 11 45 26 PM" src="https://github.com/user-attachments/assets/850556f4-aad0-4080-892a-e3d0c04579b6" />

After:

<img width="356" height="180" alt="Screenshot 2025-08-01 at 11 42 58 PM" src="https://github.com/user-attachments/assets/1a5d5f8d-b943-414b-8319-488b758dbb89" />
